### PR TITLE
feat: Add a simple contact form to the frontend with name, email and message fields

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,45 @@
+# Implementation: Add a simple contact form to the frontend with name, email and message fields
+
+## 📋 Plan-Based Implementation
+
+This pull request implements the requested functionality using a systematic plan-based approach.
+
+### 🎯 Original Task
+Add a simple contact form to the frontend with name, email and message fields
+
+### 📝 Implementation Plan
+The following plan was created and executed:
+
+
+#### Step 1: starting session | provider
+**Status**: ✅ Completed
+**Description**: openai model: gpt-4.1-mini logging to /home/user/.local/share/goose/sessions/20250711_052846.jsonl working directory: /home/user/repo [38;2;222;222;222mHere is a detailed implementation plan to add a...
+
+
+#### Step 2: [38;2;222;222;222mEach step results in a self-contained piece of working code, progressively building up to the final simple contact form on the frontend. Let me know if you want me to generate example code snippets for these steps![0m
+**Status**: ✅ Completed
+**Description**: ...
+
+
+### 🔧 Implementation Results
+- **Total Steps Planned**: 2
+- **Steps Executed**: 2
+- **Approach**: Plan-based incremental implementation
+- **Strategy**: Each step executed in isolated sessions to prevent context issues
+
+### 📁 Changes Made
+
+```
+?? src/components/ContactForm.jsx
+?? src/components/ContactForm.module.css
+```
+
+### 🧪 Testing Recommendations
+1. Verify all implemented features work as expected
+2. Test error handling and edge cases  
+3. Check integration with existing codebase
+4. Validate security and performance implications
+
+### 📚 Additional Notes
+This implementation was completed using Goose AI's plan-based approach to ensure systematic and comprehensive coverage of the requirements.
+

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import styles from './ContactForm.module.css';
+
+export default function ContactForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+
+  const [errors, setErrors] = useState({});
+  const [submitStatus, setSubmitStatus] = useState(null); // null, 'success', 'error'
+
+  const validateEmail = (email) => {
+    /*
+    Basic email regex validation
+     */
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  };
+
+  const validate = () => {
+    const newErrors = {};
+    if (!name.trim()) {
+      newErrors.name = 'Name is required.';
+    }
+    if (!email.trim()) {
+      newErrors.email = 'Email is required.';
+    } else if (!validateEmail(email)) {
+      newErrors.email = 'Invalid email format.';
+    }
+    if (!message.trim()) {
+      newErrors.message = 'Message is required.';
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setSubmitStatus(null);
+
+    if (!validate()) {
+      return;
+    }
+
+    const data = { name, email, message };
+
+    try {
+      // Here we mock API call using a timeout
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // Assume success
+      setSubmitStatus('success');
+      // Clear form
+      setName('');
+      setEmail('');
+      setMessage('');
+      setErrors({});
+    } catch (error) {
+      setSubmitStatus('error');
+    }
+  };
+
+  return (
+    <form className={styles.contactForm} onSubmit={handleSubmit} noValidate>
+      <div className={styles.field}>
+        <label htmlFor="name">Name:</label>
+        <input
+          id="name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          aria-describedby="name-error"
+          required
+        />
+        {errors.name && <span id="name-error" className={styles.error}>{errors.name}</span>}
+      </div>
+
+      <div className={styles.field}>
+        <label htmlFor="email">Email:</label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          aria-describedby="email-error"
+          required
+        />
+        {errors.email && <span id="email-error" className={styles.error}>{errors.email}</span>}
+      </div>
+
+      <div className={styles.field}>
+        <label htmlFor="message">Message:</label>
+        <textarea
+          id="message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          aria-describedby="message-error"
+          required
+        />
+        {errors.message && <span id="message-error" className={styles.error}>{errors.message}</span>}
+      </div>
+
+      <button type="submit" className={styles.submitButton}>Send</button>
+
+      {submitStatus === 'success' && (
+        <p className={styles.successMessage}>Thank you for your message!</p>
+      )}
+      {submitStatus === 'error' && (
+        <p className={styles.errorMessage}>Failed to send message. Please try again later.</p>
+      )}
+    </form>
+  );
+}

--- a/src/components/ContactForm.module.css
+++ b/src/components/ContactForm.module.css
@@ -1,0 +1,65 @@
+/* Basic styling for the contact form */
+.contactForm {
+  max-width: 400px;
+  margin: 2rem auto;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #f9f9f9;
+}
+
+.field {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  margin-bottom: 0.3rem;
+  font-weight: 600;
+}
+
+input[type="text"],
+input[type="email"],
+textarea {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.error {
+  color: #d00;
+  font-size: 0.875rem;
+  margin-top: 0.2rem;
+}
+
+.submitButton {
+  background-color: #0070f3;
+  color: white;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.submitButton:hover {
+  background-color: #005bb5;
+}
+
+.successMessage {
+  margin-top: 1rem;
+  color: #038a0a;
+  font-weight: 600;
+}
+
+.errorMessage {
+  margin-top: 1rem;
+  color: #d00;
+  font-weight: 600;
+}


### PR DESCRIPTION
# Implementation: Add a simple contact form to the frontend with name, email and message fields

## 📋 Plan-Based Implementation

This pull request implements the requested functionality using a systematic plan-based approach.

### 🎯 Original Task
Add a simple contact form to the frontend with name, email and message fields

### 📝 Implementation Plan
The following plan was created and executed:


#### Step 1: starting session | provider
**Status**: ✅ Completed
**Description**: openai model: gpt-4.1-mini logging to /home/user/.local/share/goose/sessions/20250711_052846.jsonl working directory: /home/user/repo [38;2;222;222;222mHere is a detailed implementation plan to add a...


#### Step 2: [38;2;222;222;222mEach step results in a self-contained piece of working code, progressively building up to the final simple contact form on the frontend. Let me know if you want me to generate example code snippets for these steps![0m
**Status**: ✅ Completed
**Description**: ...


### 🔧 Implementation Results
- **Total Steps Planned**: 2
- **Steps Executed**: 2
- **Approach**: Plan-based incremental implementation
- **Strategy**: Each step executed in isolated sessions to prevent context issues

### 📁 Changes Made

```
?? src/components/ContactForm.jsx
?? src/components/ContactForm.module.css
```

### 🧪 Testing Recommendations
1. Verify all implemented features work as expected
2. Test error handling and edge cases  
3. Check integration with existing codebase
4. Validate security